### PR TITLE
eupspkg.cfg.sh: set TAP_PACKAGE=1

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,4 +1,5 @@
 # Eupspkg config file. Source by 'eupspkg'
+TAP_PACKAGE=1
 
 build()
 {


### PR DESCRIPTION
Using `.tap_package` has been deprecated, in favor of a return to setting `TAP_PACKAGE=1` in `eupspkg.cfg.sh`. Because EUPS 1.5.8 through 1.5.10 don't check for `$TAP_PACKAGE`, `.tap_package` should still be present until those versions of EUPS are not in use any more.

See https://github.com/RobertLuptonTheGood/eups/pull/84 for more info