### PR TITLE
Add missing -L for libyaml

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -3,5 +3,5 @@ TAP_PACKAGE=1
 
 build()
 {
-    CFLAGS=-I${LIBYAML_DIR}/include python setup.py --with-libyaml build
+    CFLAGS=-I${LIBYAML_DIR}/include LDFLAGS=-L${LIBYAML_DIR}/lib python setup.py --with-libyaml build
 }


### PR DESCRIPTION
The recent pyyaml change to build on top of libyaml busted the Qserv base container builds.  

It looks like a necessary -L option for libyaml is missing off the LDFLAGS additions in the build() override in the eupspkg.cfg.sh; in miniconda installs this goes unnoticed since the lib is picked up from miniconda.  Since the Qserv base containers are non-miniconda builds, they broke.